### PR TITLE
feat: wire WebSocket Broadcast to task/status/priority/tag CRUD handlers

### DIFF
--- a/api/internal/handler/priorities.go
+++ b/api/internal/handler/priorities.go
@@ -6,6 +6,7 @@ import (
 	"task-manager/api/internal/api"
 	"task-manager/api/internal/auth"
 	"task-manager/api/internal/repository"
+	"task-manager/api/internal/websocket"
 
 	"github.com/google/uuid"
 )
@@ -42,6 +43,7 @@ func (h *Handler) PriorityOpsCreate(ctx context.Context, req *api.CreatePriority
 	if err != nil {
 		return nil, err
 	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "priority.changed", Payload: map[string]any{}})
 	return toAPIPriority(row), nil
 }
 
@@ -65,6 +67,7 @@ func (h *Handler) PriorityOpsUpdate(ctx context.Context, req *api.UpdatePriority
 	if err != nil {
 		return nil, errNotFound("priority not found")
 	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "priority.changed", Payload: map[string]any{}})
 	return toAPIPriority(row), nil
 }
 
@@ -79,5 +82,9 @@ func (h *Handler) PriorityOpsDelete(ctx context.Context, params api.PriorityOpsD
 		return errBadRequest("invalid priority id")
 	}
 
-	return h.q.DeletePriority(ctx, repository.DeletePriorityParams{ID: id, UserID: userID})
+	if err := h.q.DeletePriority(ctx, repository.DeletePriorityParams{ID: id, UserID: userID}); err != nil {
+		return err
+	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "priority.changed", Payload: map[string]any{}})
+	return nil
 }

--- a/api/internal/handler/statuses.go
+++ b/api/internal/handler/statuses.go
@@ -6,6 +6,7 @@ import (
 	"task-manager/api/internal/api"
 	"task-manager/api/internal/auth"
 	"task-manager/api/internal/repository"
+	"task-manager/api/internal/websocket"
 
 	"github.com/google/uuid"
 )
@@ -42,6 +43,7 @@ func (h *Handler) StatusOpsCreate(ctx context.Context, req *api.CreateStatusRequ
 	if err != nil {
 		return nil, err
 	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "status.changed", Payload: map[string]any{}})
 	return toAPIStatus(row), nil
 }
 
@@ -65,6 +67,7 @@ func (h *Handler) StatusOpsUpdate(ctx context.Context, req *api.UpdateStatusRequ
 	if err != nil {
 		return nil, errNotFound("status not found")
 	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "status.changed", Payload: map[string]any{}})
 	return toAPIStatus(row), nil
 }
 
@@ -79,5 +82,9 @@ func (h *Handler) StatusOpsDelete(ctx context.Context, params api.StatusOpsDelet
 		return errBadRequest("invalid status id")
 	}
 
-	return h.q.DeleteStatus(ctx, repository.DeleteStatusParams{ID: id, UserID: userID})
+	if err := h.q.DeleteStatus(ctx, repository.DeleteStatusParams{ID: id, UserID: userID}); err != nil {
+		return err
+	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "status.changed", Payload: map[string]any{}})
+	return nil
 }

--- a/api/internal/handler/tags.go
+++ b/api/internal/handler/tags.go
@@ -6,6 +6,7 @@ import (
 	"task-manager/api/internal/api"
 	"task-manager/api/internal/auth"
 	"task-manager/api/internal/repository"
+	"task-manager/api/internal/websocket"
 
 	"github.com/google/uuid"
 )
@@ -41,6 +42,7 @@ func (h *Handler) TagOpsCreate(ctx context.Context, req *api.CreateTagRequest) (
 	if err != nil {
 		return nil, err
 	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "tag.changed", Payload: map[string]any{}})
 	return toAPITag(row), nil
 }
 
@@ -63,6 +65,7 @@ func (h *Handler) TagOpsUpdate(ctx context.Context, req *api.UpdateTagRequest, p
 	if err != nil {
 		return nil, errNotFound("tag not found")
 	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "tag.changed", Payload: map[string]any{}})
 	return toAPITag(row), nil
 }
 
@@ -77,5 +80,9 @@ func (h *Handler) TagOpsDelete(ctx context.Context, params api.TagOpsDeleteParam
 		return errBadRequest("invalid tag id")
 	}
 
-	return h.q.DeleteTag(ctx, repository.DeleteTagParams{ID: id, UserID: userID})
+	if err := h.q.DeleteTag(ctx, repository.DeleteTagParams{ID: id, UserID: userID}); err != nil {
+		return err
+	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "tag.changed", Payload: map[string]any{}})
+	return nil
 }

--- a/api/internal/handler/tasks.go
+++ b/api/internal/handler/tasks.go
@@ -6,6 +6,7 @@ import (
 	"task-manager/api/internal/api"
 	"task-manager/api/internal/auth"
 	"task-manager/api/internal/repository"
+	"task-manager/api/internal/websocket"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -87,6 +88,7 @@ func (h *Handler) TaskOpsCreate(ctx context.Context, req *api.CreateTaskRequest)
 
 	result := toAPITaskFromTask(task)
 	result.TagIds = req.TagIds
+	h.hub.Broadcast(userID, websocket.Event{Type: "task.changed", Payload: map[string]any{}})
 	return &result, nil
 }
 
@@ -177,6 +179,7 @@ func (h *Handler) TaskOpsUpdate(ctx context.Context, req *api.UpdateTaskRequest,
 
 	result := toAPITaskFromTask(task)
 	result.TagIds = req.TagIds
+	h.hub.Broadcast(userID, websocket.Event{Type: "task.changed", Payload: map[string]any{}})
 	return &result, nil
 }
 
@@ -191,5 +194,9 @@ func (h *Handler) TaskOpsDelete(ctx context.Context, params api.TaskOpsDeletePar
 		return errBadRequest("invalid task id")
 	}
 
-	return h.q.DeleteTask(ctx, repository.DeleteTaskParams{ID: id, UserID: userID})
+	if err := h.q.DeleteTask(ctx, repository.DeleteTaskParams{ID: id, UserID: userID}); err != nil {
+		return err
+	}
+	h.hub.Broadcast(userID, websocket.Event{Type: "task.changed", Payload: map[string]any{}})
+	return nil
 }


### PR DESCRIPTION
各 CRUD 操作（Create・Update・Delete）の成功後に hub.Broadcast を呼び出し、 対象ユーザーへリアルタイムイベント（task.changed / status.changed /
priority.changed / tag.changed）を配信するよう配線した。